### PR TITLE
Add markdown support

### DIFF
--- a/Profile/Components/App.razor
+++ b/Profile/Components/App.razor
@@ -5,7 +5,13 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
+    @* 
+        works for isolation CSS in blazor server app in compile time
+        <link rel="stylesheet" href="Profile.styles.css" />
+    *@
     <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="blog.css" />
+   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/default.min.css">
     <link rel="icon" type="image/svg" href="logo-min.svg" />
     <HeadOutlet />
 </head>
@@ -13,6 +19,8 @@
 <body>
     <Routes />
     <script src="_framework/blazor.web.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+   <script src="syntaxHighLight.js"></script>
 </body>
 
 </html>

--- a/Profile/Components/Pages/BlogPost.razor
+++ b/Profile/Components/Pages/BlogPost.razor
@@ -1,0 +1,56 @@
+@using YamlDotNet.Serialization
+@using YamlDotNet.Serialization.NamingConventions
+@using YamlDotNet.Core
+@using YamlDotNet.Core.Events
+@using Profile.Models
+@inject IHostEnvironment Env
+@inject IJSRuntime JS
+@inject NavigationManager NavigationManager
+@rendermode InteractiveServer
+
+@page "/dsa/{slug:nonfile}"
+
+<PageTitle>dsa/@Slug</PageTitle>
+
+<div class="markdown-body">
+  @((MarkupString)post.Content)
+</div>
+
+@code {
+  [Parameter]
+
+  public String Slug{get; set;} = string.Empty;
+  public Post post = new();
+  //private IJSObjectReference? module;
+  protected override async Task OnInitializedAsync() {
+
+    String folderPath = String.Concat(Env.ContentRootPath, "/wwwroot", "/dsa", $"/{Slug}.md");
+    var document = await File.ReadAllTextAsync(folderPath);
+    if (document is null ) {
+      NavigationManager.NavigateTo("/Error");
+      return;
+    }
+
+    var yamlDeserializer = new DeserializerBuilder()
+                  .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                  .Build();
+
+    using (var input = new StringReader(document)) {
+        var parser = new Parser(input);
+        parser.Consume<StreamStart>();
+        parser.Consume<DocumentStart>();
+        post = yamlDeserializer.Deserialize<Post>(parser);
+        parser.Consume<DocumentEnd>();
+    }
+
+    post.Content = Markdown.Parse(document);
+  }
+
+  protected async override Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("codeSyntaxHighlight");
+        }
+    }
+}

--- a/Profile/Components/Pages/DSA.razor
+++ b/Profile/Components/Pages/DSA.razor
@@ -1,5 +1,52 @@
+@using Microsoft.AspNetCore.Hosting
+@using YamlDotNet.Serialization
+@using YamlDotNet.Serialization.NamingConventions
+@using YamlDotNet.Core
+@using YamlDotNet.Core.Events
+@using Profile.Models
+@inject IHostEnvironment Env
 @page "/dsa"
 
 <PageTitle>dsa</PageTitle>
-<h1 class="font-bold text-2xl mb-5">Data Structures and Algorithms</h1>
-<p class="text-xl">Coming soon ...</p>
+<h1 class="font-bold text-3xl mb-5 bg-[#fe7f9d] p-5 rounded-lg text-center">Data Structures and Algorithms</h1>
+
+<div>
+    @foreach (var post in posts) {
+    <ul class="flex flex-col gap-y-1.5 mb-2">
+        <li><h1 class="text-3xl font-bold"><a class="no-underline hover:underline" href="@post.GetUrl()">@post.Title</a></h1></li>
+        <li class="mb-1.5 flex flex-row gap-x-2 italic items-center">
+          <span class="font-medium text-lg">@post.Author</span>
+          <span>-</span>
+          <span class="font-bold text-sm text-white/90">@post.GetFormattedDate()</span>
+          </li>
+        <li><p class="text-lg text-pretty">@post.Description</p></li>
+    </ul>
+    <hr class="w-full h-0.5 bg-[#fe7f9d] border-[#fe0100] rounded-2xl mb-5">
+    }
+</div>
+
+@code {
+    private List<Post> posts = new();
+    //private Post post = new();
+    protected override async Task OnInitializedAsync() {
+      var folderPath = String.Concat(Env.ContentRootPath, "/wwwroot", "/dsa");
+
+      var yamlDeserializer = new DeserializerBuilder()
+                    .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                    .Build();
+
+      foreach (var filePath in Directory.GetFiles(folderPath)) {
+        var document = await File.ReadAllTextAsync(filePath);
+        using (var input = new StringReader(document))
+        {
+            var parser = new Parser(input);
+            parser.Consume<StreamStart>();
+            parser.Consume<DocumentStart>();
+            var post = yamlDeserializer.Deserialize<Post>(parser);
+            posts.Add(post);
+            parser.Consume<DocumentEnd>();
+        }
+      }
+      posts.Sort((s1, s2) => s1.GetDateWithType().CompareTo(s2.GetDateWithType()));
+    }
+}

--- a/Profile/Components/_Imports.razor
+++ b/Profile/Components/_Imports.razor
@@ -7,8 +7,8 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 
-@* 
-  Maybe don't is necessary users this components 
+@*
+  Maybe don't is necessary users this components
   @using Profile
   @using Profile.Components
 *@

--- a/Profile/Models/Markdown.cs
+++ b/Profile/Models/Markdown.cs
@@ -1,0 +1,12 @@
+using Westwind.Web.Markdown.MarkdownParser;
+
+public static class Markdown {
+    public static string Parse(string markdown, bool usePragmaLines = false, bool forceReload = false)
+    {
+        if (string.IsNullOrEmpty(markdown))
+            return "";
+
+        var parser = MarkdownParserFactory.GetParser(usePragmaLines, forceReload);
+        return parser.Parse(markdown);
+    }
+}

--- a/Profile/Models/Markdown.cs
+++ b/Profile/Models/Markdown.cs
@@ -1,6 +1,7 @@
 using Westwind.Web.Markdown.MarkdownParser;
 
-public static class Markdown {
+public static class Markdown
+{
     public static string Parse(string markdown, bool usePragmaLines = false, bool forceReload = false)
     {
         if (string.IsNullOrEmpty(markdown))

--- a/Profile/Models/Post.cs
+++ b/Profile/Models/Post.cs
@@ -1,0 +1,24 @@
+namespace Profile.Models;
+
+public class Post {
+  public String? Title {get; set;}
+  public String? Description {get; set;}
+  public String? Author {get; set;}
+  public String? Date {get; set;}
+  public String? Slug {get; set;}
+
+  public String? Content {get; set;}
+
+  public String GetUrl() {
+    return $"/dsa/{Slug}";
+  }
+
+  public String GetFormattedDate() {
+    return GetDateWithType().ToString("MMMM, dd, yyy");
+  }
+
+  public DateTime GetDateWithType() {
+    return DateTime.Parse(Date);
+  }
+}
+

--- a/Profile/Models/Post.cs
+++ b/Profile/Models/Post.cs
@@ -1,24 +1,28 @@
 namespace Profile.Models;
 
-public class Post {
-  public String? Title {get; set;}
-  public String? Description {get; set;}
-  public String? Author {get; set;}
-  public String? Date {get; set;}
-  public String? Slug {get; set;}
+public class Post
+{
+    public String? Title { get; set; }
+    public String? Description { get; set; }
+    public String? Author { get; set; }
+    public String? Date { get; set; }
+    public String? Slug { get; set; }
 
-  public String? Content {get; set;}
+    public String? Content { get; set; }
 
-  public String GetUrl() {
-    return $"/dsa/{Slug}";
-  }
+    public String GetUrl()
+    {
+        return $"/dsa/{Slug}";
+    }
 
-  public String GetFormattedDate() {
-    return GetDateWithType().ToString("MMMM, dd, yyy");
-  }
+    public String GetFormattedDate()
+    {
+        return GetDateWithType().ToString("MMMM, dd, yyy");
+    }
 
-  public DateTime GetDateWithType() {
-    return DateTime.Parse(Date);
-  }
+    public DateTime GetDateWithType()
+    {
+        return DateTime.Parse(Date);
+    }
 }
 

--- a/Profile/Profile.csproj
+++ b/Profile/Profile.csproj
@@ -6,4 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Westwind.Web.Markdown" Version="0.2.15" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/Profile/Properties/launchSettings.json
+++ b/Profile/Properties/launchSettings.json
@@ -14,7 +14,7 @@
       "http": {
         "commandName": "Project",
         "dotnetRunMessages": true,
-        "launchBrowser": true,
+        "launchBrowser": false,
         "applicationUrl": "http://localhost:5154",
         "environmentVariables": {
           "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Profile/wwwroot/blog.css
+++ b/Profile/wwwroot/blog.css
@@ -1,0 +1,77 @@
+
+.markdown-body h1,h2,h3 {
+  margin-bottom: 12px; 
+  font-weight: 700;
+}
+.markdown-body h1 {
+  font-size: 35px;
+}
+
+.markdown-body h2 {
+  font-size: 30px;
+}
+
+.markdown-body h3 {
+  font-size: 24px;
+}
+
+.markdown-body p {
+  margin-bottom: 12px;
+  font-size: 18px;
+  font-weight: normal;
+  text-wrap: pretty;
+}
+
+.markdown-body em {
+  color: #fe7f9d;
+}
+
+.markdown-body strong {
+  font-weight: 900;
+}
+
+.markdown-body pre {
+  margin-bottom: 12px;
+}
+
+.markdown-body ul,
+ol {
+  /* user-agent styles */
+  display: block;
+  list-style-type: disc;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  padding-inline-start: 40px;
+  margin-bottom: 12px;
+  font-size: 18px;
+}
+.markdown-body ol {
+  list-style-type: decimal;
+}
+
+.markdown-body li {
+  display: list-item;
+  text-align: match-parent;
+}
+::marker {
+  font-weight: 900;
+  unicode-bidi: isolate;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+}
+
+.markdown-body a {
+  font-size: 18px;
+  color: #fe7f9d;
+  font-weight: 600;
+}
+
+.markdown-body a:hover {
+  text-decoration: underline;
+}
+
+.markdown-body img {
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 12px;
+}

--- a/Profile/wwwroot/dsa/blog-1.md
+++ b/Profile/wwwroot/dsa/blog-1.md
@@ -1,0 +1,34 @@
+---
+slug: "blog-1"
+title: "Blog 1"
+description: "This is the Blog 1"
+author: "keliumJU"
+date: "02/09/2025 01:43:30"
+---
+
+# Blog 1
+
+This is the content for the blog 1 it's only a test
+
+```js
+let x = 5;
+console.log(5);
+```
+
+* item 1 
+* item 2
+* item 3
+
+Content after this section is only a test mode or a only a test mode by 2, that are random words don't have importance.
+
+1. item 1 with a large content for this is a important topic that i know that i can speak but is a large line that is very necessary that appear in the second line.
+2. item 2
+3. item 3
+
+[This is a link](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type)
+
+![Alt text](https://imgsrv.crunchyroll.com/cdn-cgi/image/fit=cover,format=auto,quality=85,width=1920/keyart/GYX0ZW80R-backdrop_wide "Soul Eater")
+
+## This is Maka!
+
+![Alt text](https://i.pinimg.com/736x/fc/e8/14/fce814f9047f70c11b3f29f753fd90d3.jpg "Maka")

--- a/Profile/wwwroot/dsa/blog-2.md
+++ b/Profile/wwwroot/dsa/blog-2.md
@@ -1,0 +1,27 @@
+---
+slug: "blog-2"
+title: "Blog 2"
+description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris pellentesque pretium lorem. Integer ut luctus ipsum. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Pellentesque a nisl erat. Duis id massa ex. Suspendisse vestibulum ante congue est aliquam, ac rutrum dui pellentesque. Donec fringilla orci sodales tellus dictum iaculis. Proin neque felis, porttitor vitae nisi id, molestie pharetra metus. Vivamus id commodo nulla. Phasellus tempor tempor nisi, a rutrum velit porta ut. Sed tristique pulvinar faucibus. Duis feugiat ac elit ac posuere."
+author: "keliumJU"
+date: "02/09/2025 15:30:15"
+---
+
+# Blog 2
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris pellentesque pretium lorem. Integer ut luctus ipsum. Class aptent taciti sociosqu ad litora torquent per conubia **nostra**, per inceptos himenaeos. Pellentesque a nisl erat. Duis id massa ex. Suspendisse **vestibulum** ante congue est aliquam, ac rutrum dui pellentesque. Donec fringilla orci _sodales_ tellus dictum iaculis. Proin neque felis, porttitor vitae nisi id, molestie pharetra metus. Vivamus id commodo nulla. Phasellus tempor tempor nisi, a rutrum __velit__ porta ut. Sed tristique pulvinar faucibus. Duis feugiat ac elit ac posuere.
+
+```rust
+let i = 0;
+if i == 0 {
+  println!("Is Zero")
+}else {
+  println!("Don't is ZERO :(")
+}
+```
+
+This is an example with c# code
+
+```csharp
+var x = 0;
+Console.WriteLine($"{x}");
+```

--- a/Profile/wwwroot/styles.css
+++ b/Profile/wwwroot/styles.css
@@ -536,6 +536,9 @@
   .static {
     position: static;
   }
+  .isolate {
+    isolation: isolate;
+  }
   .z-\[-1\] {
     z-index: -1;
   }
@@ -560,29 +563,23 @@
       max-width: 96rem;
     }
   }
-  .mx-3 {
-    margin-inline: calc(var(--spacing) * 3);
-  }
   .mx-5 {
     margin-inline: calc(var(--spacing) * 5);
   }
-  .mr-5 {
-    margin-right: calc(var(--spacing) * 5);
-  }
-  .mr-10 {
-    margin-right: calc(var(--spacing) * 10);
-  }
   .mr-auto {
     margin-right: auto;
+  }
+  .mb-1 {
+    margin-bottom: calc(var(--spacing) * 1);
+  }
+  .mb-1\.5 {
+    margin-bottom: calc(var(--spacing) * 1.5);
   }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }
   .mb-5 {
     margin-bottom: calc(var(--spacing) * 5);
-  }
-  .ml-5 {
-    margin-left: calc(var(--spacing) * 5);
   }
   .ml-auto {
     margin-left: auto;
@@ -612,11 +609,11 @@
     width: calc(var(--spacing) * 6);
     height: calc(var(--spacing) * 6);
   }
-  .h-4 {
-    height: calc(var(--spacing) * 4);
+  .h-0 {
+    height: calc(var(--spacing) * 0);
   }
-  .h-6 {
-    height: calc(var(--spacing) * 6);
+  .h-0\.5 {
+    height: calc(var(--spacing) * 0.5);
   }
   .h-7 {
     height: calc(var(--spacing) * 7);
@@ -627,17 +624,11 @@
   .min-h-screen {
     min-height: 100vh;
   }
-  .w-4 {
-    width: calc(var(--spacing) * 4);
-  }
   .w-5 {
     width: calc(var(--spacing) * 5);
   }
   .w-5\/6 {
     width: calc(5/6 * 100%);
-  }
-  .w-6 {
-    width: calc(var(--spacing) * 6);
   }
   .w-7 {
     width: calc(var(--spacing) * 7);
@@ -690,11 +681,23 @@
   .gap-10 {
     gap: calc(var(--spacing) * 10);
   }
+  .gap-x-2 {
+    column-gap: calc(var(--spacing) * 2);
+  }
   .gap-x-10 {
     column-gap: calc(var(--spacing) * 10);
   }
+  .gap-y-1 {
+    row-gap: calc(var(--spacing) * 1);
+  }
+  .gap-y-1\.5 {
+    row-gap: calc(var(--spacing) * 1.5);
+  }
   .gap-y-5 {
     row-gap: calc(var(--spacing) * 5);
+  }
+  .rounded-2xl {
+    border-radius: var(--radius-2xl);
   }
   .rounded-full {
     border-radius: calc(infinity * 1px);
@@ -708,6 +711,9 @@
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
+  }
+  .border-\[\#fe0100\] {
+    border-color: #fe0100;
   }
   .bg-\[\#021830\] {
     background-color: #021830;
@@ -764,6 +770,10 @@
     font-size: var(--text-2xl);
     line-height: var(--tw-leading, var(--text-2xl--line-height));
   }
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
+  }
   .text-4xl {
     font-size: var(--text-4xl);
     line-height: var(--tw-leading, var(--text-4xl--line-height));
@@ -771,6 +781,10 @@
   .text-lg {
     font-size: var(--text-lg);
     line-height: var(--tw-leading, var(--text-lg--line-height));
+  }
+  .text-sm {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
   }
   .text-xl {
     font-size: var(--text-xl);
@@ -788,6 +802,9 @@
     --tw-font-weight: var(--font-weight-normal);
     font-weight: var(--font-weight-normal);
   }
+  .text-pretty {
+    text-wrap: pretty;
+  }
   .text-wrap {
     text-wrap: wrap;
   }
@@ -797,6 +814,19 @@
   .text-white {
     color: var(--color-white);
   }
+  .text-white\/90 {
+    color: color-mix(in oklab, var(--color-white) 90%, transparent);
+  }
+  .italic {
+    font-style: italic;
+  }
+  .tabular-nums {
+    --tw-numeric-spacing: tabular-nums;
+    font-variant-numeric: var(--tw-ordinal,) var(--tw-slashed-zero,) var(--tw-numeric-figure,) var(--tw-numeric-spacing,) var(--tw-numeric-fraction,);
+  }
+  .no-underline {
+    text-decoration-line: none;
+  }
   .underline {
     text-decoration-line: underline;
   }
@@ -804,36 +834,8 @@
     outline-style: var(--tw-outline-style);
     outline-width: 1px;
   }
-  .blur {
-    --tw-blur: blur(8px);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .blur-md {
-    --tw-blur: blur(var(--blur-md));
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .contrast-200 {
-    --tw-contrast: contrast(200%);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .grayscale {
-    --tw-grayscale: grayscale(100%);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
   .invert {
     --tw-invert: invert(100%);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .sepia {
-    --tw-sepia: sepia(100%);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .sepia-\[\#fffff\] {
-    --tw-sepia: sepia(#fffff);
-    filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
-  }
-  .sepia-\[\#ffffff\] {
-    --tw-sepia: sepia(#ffffff);
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
   .filter {
@@ -857,6 +859,13 @@
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-gray-400);
+      }
+    }
+  }
+  .hover\:underline {
+    &:hover {
+      @media (hover: hover) {
+        text-decoration-line: underline;
       }
     }
   }
@@ -1052,6 +1061,26 @@
   initial-value: 100%;
 }
 @property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-ordinal {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-slashed-zero {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-figure {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-spacing {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-numeric-fraction {
   syntax: "*";
   inherits: false;
 }

--- a/Profile/wwwroot/syntaxHighLight.js
+++ b/Profile/wwwroot/syntaxHighLight.js
@@ -1,0 +1,3 @@
+function codeSyntaxHighlight() {
+  hljs.highlightAll();
+}


### PR DESCRIPTION
### Description
In this PR was added the markdown support to convert `.md `files to html that are render in a `.razor` file in a blazor server app

### Features
* Convert .md files to html that are render in .razor files
* Basic styles for posts with support for the next html tags: `h1,h2,h3,ul,ol,li,p,img,a`
* Syntax Highlight for `csharp`, `rust` and `js` code